### PR TITLE
fix: set nameOverride field in macro chart

### DIFF
--- a/charts/kubefirst-pro/values.yaml
+++ b/charts/kubefirst-pro/values.yaml
@@ -1,6 +1,10 @@
-console:
-  domain: kubefirst.dev
 global:
   kubefirst-pro-apiVersion: v2.7.7-rc4
   kubefirst-pro-uiVersion: v2.7.7-rc3
   kubefirstVersion: v2.7.7
+
+kubefirst-pro-api:
+  nameOverride: "pro-api"
+
+kubefirst-pro-ui:
+  nameOverride: "pro-ui"

--- a/charts/kubefirst/values.yaml
+++ b/charts/kubefirst/values.yaml
@@ -1,5 +1,3 @@
-console:
-  domain: kubefirst.dev
 global:
   consoleVersion: v2.7.5-rc6
   kubefirst-api-eeVersion: v2.6.1-rc2
@@ -7,3 +5,10 @@ global:
   kubefirstVersion: v2.7.7
 kubefirst-api-ee:
   existingSecret: kubefirst-initial-secrets
+
+kubefirst-api:
+  nameOverride: "api"
+
+console:
+  nameOverride: "console"
+  domain: kubefirst.dev


### PR DESCRIPTION
## Description
Add the `nameOverride` field in the sub-chart's to prevent duplication in resource name.
