### PR TITLE
prepare the 0.2.1 patch release for candidates

### DIFF
--- a/charts/colony/Chart.yaml
+++ b/charts/colony/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 description: Colony helm chart
 name: colony
 type: application
-version: 0.2.0
+version: 0.2.1-rc0


### PR DESCRIPTION
## Description
after a release, we prep the chart for the next anticipated release track, whether that be a patch, minor, or major release that is expected next, with an rc0 to prep for an rc1 on the first release track publish. we are anticipating multiple patch releases to the 0.2 track.